### PR TITLE
Add `slot_data` connect argument

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -187,6 +187,7 @@ export class Client<TSlotData = SlotData> {
                     uuid: info.uuid ?? generateUUIDv4(),
                     tags: info.tags ?? [],
                     password: info.password ?? "",
+                    slot_data: info.slot_data ?? true,
                 },
             );
         });

--- a/src/packets/ConnectPacket.ts
+++ b/src/packets/ConnectPacket.ts
@@ -26,6 +26,9 @@ export interface ConnectPacket extends BaseClientPacket {
     /** Denotes special features or capabilities that the sender is currently capable of. */
     tags: string[];
 
+    /** If true, the Connect answer will contain slot_data */
+    slot_data: boolean;
+
     /** An object representing the minimum Archipelago server version this client supports. */
     version: NetworkVersion;
 

--- a/src/types/ConnectionInformation.ts
+++ b/src/types/ConnectionInformation.ts
@@ -41,6 +41,9 @@ export type ConnectionInformation = {
     /** Denotes special features or capabilities that the sender is currently capable of. */
     tags?: string[];
 
+    /** If true, the Connect answer will contain slot_data */
+    slot_data?: boolean;
+
     /**
      * Bit flags configuring which items should be sent by the server. Read {@link ItemsHandlingFlags} for information
      * on individual flags.


### PR DESCRIPTION
`slot_data` was missing from the connect arguments as the network protocol has, so this just adds that in. I'm not sure if the default argument should be true or false, but I feel like true is the better default to have, as most users would be using the js library for games that would need the slot_data.