### PR TITLE
Set ItemManager index to correct value after ReceivedItems

### DIFF
--- a/src/managers/ItemsManager.ts
+++ b/src/managers/ItemsManager.ts
@@ -128,5 +128,7 @@ export class ItemsManager {
         for (const item of packet.items) {
             this.#items[index++] = item;
         }
+
+        this.#index = index;
     }
 }


### PR DESCRIPTION
I noticed in the CrossCode APWorld that every time an item was received, my client would send a `Sync` Packet and the server would, naturally, respond with a `ReceivedItems` packet with `index=0`. This turned out to be an oversight in `ItemsManager.#onReceivedItems` in which the program would fail to update `#index` to the new value, therefore keeping `#index` constantly at zero, and creating some unnecessary network bandwidth. This PR adds a whopping one line of code that should fix this issue.