### PR TITLE
archipelago.js@2.0.0-rc6 Changes

### DIFF
--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -45,8 +45,8 @@ import { Client } from "archipelago.js";
 const client = new Client();
 
 // Setup a listener for incoming chat messages and print them to the console.
-client.messages.on("message", (message, sender) => {
-    console.log(`${sender}: ${message}`);
+client.messages.on("chat", (message, sender) => {
+    console.log(`${sender.alias}: ${message}`);
 });
 
 // Connect to the Archipelago server (replace url, slot name, and game as appropriate for your scenario).

--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -45,10 +45,9 @@ import { Client } from "archipelago.js";
 const client = new Client();
 
 // Setup a listener for incoming chat messages and print them to the console.
-client.messages
-    .on("chatMessage", (message, _, sender) => {
-        console.log(`${sender}: ${message}`);
-    });
+client.messages.on("message", (message, sender) => {
+    console.log(`${sender}: ${message}`);
+});
 
 // Connect to the Archipelago server (replace url, slot name, and game as appropriate for your scenario).
 await client.login("wss://archipelago.gg:38281", "Phar", "Clique");
@@ -66,12 +65,11 @@ You can also listen for events, such as when your client receives items from the
 
 ```js
 // Setup a listener for whenever items are received and log the details.
-client.items
-    .on("itemsReceived", (items) => {
-        for (const item of items) {
-            console.log(`Received item ${item} from player ${item.sender}.`);
-        }
-    });
+client.items.on("itemsReceived", (items) => {
+    for (const item of items) {
+        console.log(`Received item ${item} from player ${item.sender}.`);
+    }
+});
 
 // ... misc client code below ...
 ```
@@ -80,10 +78,9 @@ Or if another player changes their alias:
 
 ```js
 // Setup a listener for when a player's alias (name) changes.
-client.players
-    .on("aliasUpdated", (_, oldAlias, newAlias) => {
-        console.log(`${oldAlias} has changed their alias to ${newAlias}.`);
-    });
+client.players.on("aliasUpdated", (_, oldAlias, newAlias) => {
+    console.log(`${oldAlias} has changed their alias to ${newAlias}.`);
+});
 
 // ... misc client code below ...
 ```
@@ -92,16 +89,15 @@ Or if you're using the DeathLink mechanic and another player dies:
 
 ```js
 // Setup a listener for when another DeathLink player dies.
-client.deathLink
-    .on("deathReceived", (source, time, cause) => {
-        if (cause) {
-            console.log(`DeathLink received from ${source}: ${cause}`);
-            return;
-        }
-        
-        // No cause was supplied.
-        console.log(`DeathLink received from ${source}!`);
-    });
+client.deathLink.on("deathReceived", (source, time, cause) => {
+    if (cause) {
+        console.log(`DeathLink received from ${source}: ${cause}`);
+        return;
+    }
+    
+    // No cause was supplied.
+    console.log(`DeathLink received from ${source}!`);
+});
 
 // ... misc client code below ...
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "archipelago.js",
-    "version": "2.0.0-rc5",
+    "version": "2.0.0-rc6",
     "description": "A runtime-agnostic and zero dependency TypeScript/JavaScript library for communicating with Archipelago servers.",
     "license": "MIT",
     "type": "module",

--- a/src/classes/Client.ts
+++ b/src/classes/Client.ts
@@ -314,7 +314,7 @@ export class Client {
             this,
             item,
             this.players.self,
-            this.players.findPlayer(this.players.self.team, item.player) as Player),
+            this.players.findPlayer(item.player) as Player),
         );
     }
 

--- a/src/classes/Client.ts
+++ b/src/classes/Client.ts
@@ -1,10 +1,4 @@
-import {
-    clientStatuses,
-    ConnectedPacket,
-    ConnectionRefusedPacket,
-    ConnectPacket,
-    JSONRecord,
-} from "../api";
+import { clientStatuses, ConnectedPacket, ConnectionRefusedPacket, ConnectPacket, JSONRecord } from "../api";
 import { ArgumentError, LoginError, SocketError, UnauthenticatedError } from "../errors.ts";
 import { ClientOptions, defaultClientOptions } from "../interfaces/ClientOptions.ts";
 import { ConnectionOptions, defaultConnectionOptions } from "../interfaces/ConnectionOptions.ts";
@@ -313,7 +307,7 @@ export class Client {
             .send({ cmd: "LocationScouts", create_as_hint: createHint, locations })
             .wait("locationInfo", (packet) => {
                 // Easy way to check if both lists are identical.
-                return packet.locations.toSorted().join(",") === locations.toSorted().join(",");
+                return packet.locations.map((location) => location.location).toSorted().join(",") === locations.toSorted().join(",");
             });
 
         return response.locations.map((item) => new Item(

--- a/src/classes/Hint.ts
+++ b/src/classes/Hint.ts
@@ -23,8 +23,8 @@ export class Hint {
         this.#item = new Item(
             this.#client,
             { item: hint.item, location: hint.location, player: hint.finding_player, flags: hint.item_flags },
-            this.#client.players.findPlayer(this.#client.players.self.team, hint.finding_player) as Player,
-            this.#client.players.findPlayer(this.#client.players.self.team, hint.receiving_player) as Player,
+            this.#client.players.findPlayer(hint.finding_player) as Player,
+            this.#client.players.findPlayer(hint.receiving_player) as Player,
         );
     }
 

--- a/src/classes/MessageNode.ts
+++ b/src/classes/MessageNode.ts
@@ -1,0 +1,227 @@
+import {
+    ColorJSONMessagePart,
+    ItemJSONMessagePart,
+    JSONMessagePart,
+    LocationJSONMessagePart,
+    NetworkItem,
+    TextJSONMessagePart,
+    ValidJSONColorType,
+} from "../api";
+import { Client } from "./Client.ts";
+import { Item } from "./Item.ts";
+import { PackageMetadata } from "./PackageMetadata.ts";
+import { Player } from "./Player.ts";
+
+/**
+ * The base class for all message node objects.
+ */
+export abstract class BaseMessageNode {
+    /** The client object containing additional context metadata. */
+    protected readonly client: Client;
+
+    /** The underlying message part component. */
+    protected readonly part: JSONMessagePart;
+
+    /** The type of this message node. */
+    public readonly abstract type: string;
+
+    /**
+     * Instantiates a new message node object.
+     * @internal
+     * @param client The client object containing additional context metadata for this node.
+     * @param part The underlying message part component from the network protocol.
+     * @protected
+     */
+    protected constructor(client: Client, part: JSONMessagePart) {
+        this.client = client;
+        this.part = part;
+    }
+
+    /**
+     * Returns the plaintext component of this message node.
+     * @remarks Same value returned from `.toString()`.
+     */
+    public abstract get text(): string;
+
+    /** Returns the plaintext component of this message node. */
+    public toString(): string {
+        return this.text;
+    };
+}
+
+/**
+ * A message node object containing item metadata.
+ */
+export class ItemMessageNode extends BaseMessageNode {
+    protected override readonly part: ItemJSONMessagePart;
+    public readonly type = "item" as const;
+
+    /** The item this node is referring to. */
+    public readonly item: Item;
+
+    /**
+     * Instantiates a new message node object.
+     * @internal
+     * @param client The client object containing additional context metadata for this node.
+     * @param part The underlying message part component from the network protocol.
+     * @param item The network item in reference to this message node.
+     * @param receiver The player to receive this item.
+     */
+    public constructor(client: Client, part: ItemJSONMessagePart, item: NetworkItem, receiver: Player) {
+        super(client, part);
+
+        const player = client.players.findPlayer(part.player, receiver.team) as Player;
+        this.part = part;
+        this.item = new Item(client, item, player, receiver);
+    }
+
+    /** Returns the name of this item. */
+    public get text(): string {
+        return this.item.name;
+    }
+}
+
+/**
+ * A message node object containing location metadata.
+ */
+export class LocationMessageNode extends BaseMessageNode {
+    readonly #name: string;
+
+    protected override readonly part: LocationJSONMessagePart;
+    public readonly type = "location" as const;
+
+    /** The integer id of this location. */
+    public readonly id: number;
+
+    /**
+     * Instantiates a new message node object.
+     * @internal
+     * @param client The client object containing additional context metadata for this node.
+     * @param part The underlying message part component from the network protocol.
+     */
+    public constructor(client: Client, part: LocationJSONMessagePart) {
+        super(client, part);
+
+        const player = client.players.findPlayer(part.player) as Player;
+        const pkg = client.package.findPackage(player.game) as PackageMetadata;
+        this.part = part;
+        if (part.type === "location_name") {
+            this.#name = part.text;
+            this.id = pkg.locationTable[part.text];
+        } else {
+            this.id = parseInt(part.text);
+            this.#name = client.package.lookupLocationName(player.game, this.id, true);
+        }
+    }
+
+    /** Returns the name of this location. */
+    public get text(): string {
+        return this.#name;
+    }
+}
+
+/**
+ * A message node object containing explicit color metadata.
+ */
+export class ColorMessageNode extends BaseMessageNode {
+    protected override readonly part: ColorJSONMessagePart;
+    public readonly type = "color" as const;
+
+    /** The explicit color (or style) of this node. */
+    public readonly color: ValidJSONColorType;
+
+    /**
+     * Instantiates a new message node object.
+     * @internal
+     * @param client The client object containing additional context metadata for this node.
+     * @param part The underlying message part component from the network protocol.
+     */
+    public constructor(client: Client, part: ColorJSONMessagePart) {
+        super(client, part);
+
+        this.part = part;
+        this.color = part.color;
+    }
+
+    public get text(): string {
+        return this.part.text;
+    }
+}
+
+/**
+ * A message node object containing explicit color metadata.
+ */
+export class TextualMessageNode extends BaseMessageNode {
+    protected override readonly part: TextJSONMessagePart;
+    public readonly type: "text" | "entrance";
+
+    /**
+     * Instantiates a new message node object.
+     * @internal
+     * @param client The client object containing additional context metadata for this node.
+     * @param part The underlying message part component from the network protocol.
+     */
+    public constructor(client: Client, part: TextJSONMessagePart) {
+        super(client, part);
+
+        this.part = part;
+        if (this.part.type === "entrance_name") {
+            this.type = "entrance";
+        } else {
+            this.type = "text";
+        }
+    }
+
+    public get text(): string {
+        return this.part.text;
+    }
+}
+
+/**
+ * A message node object containing explicit color metadata.
+ */
+export class PlayerMessageNode extends BaseMessageNode {
+    protected override readonly part: TextJSONMessagePart;
+    public readonly type = "player" as const;
+
+    /** The player being referenced by this node. */
+    public readonly player: Player;
+
+    /**
+     * Instantiates a new message node object.
+     * @internal
+     * @param client The client object containing additional context metadata for this node.
+     * @param part The underlying message part component from the network protocol.
+     */
+    public constructor(client: Client, part: TextJSONMessagePart) {
+        super(client, part);
+
+        this.part = part;
+        if (part.type === "player_id") {
+            this.player = client.players.findPlayer(parseInt(part.text)) as Player;
+        } else {
+            // Need to work a bit harder here.
+            const player = client.players.teams[client.players.self.team].find((p) => p.name === part.text);
+            if (!player) {
+                throw new Error(`Cannot find player under name: ${part.text}`);
+            }
+
+            this.player = player;
+        }
+    }
+
+    /** The current alias of this player. */
+    public get text(): string {
+        return this.player.alias;
+    }
+}
+
+/**
+ * A type union of all known message node types. See each type for more information.
+ */
+export type MessageNode =
+    | ItemMessageNode
+    | LocationMessageNode
+    | ColorMessageNode
+    | TextualMessageNode
+    | PlayerMessageNode;

--- a/src/classes/PackageMetadata.ts
+++ b/src/classes/PackageMetadata.ts
@@ -18,10 +18,10 @@ export class PackageMetadata {
     public readonly locationTable: Readonly<Record<string, number>>;
 
     /** A record of ids to names for all items in this game package. */
-    public readonly reverseItemTable: Readonly<Record<string, string>>;
+    public readonly reverseItemTable: Readonly<Record<number, string>>;
 
     /** A record of ids to names for all locations in this game package. */
-    public readonly reverseLocationTable: Readonly<Record<string, string>>;
+    public readonly reverseLocationTable: Readonly<Record<number, string>>;
 
     /**
      * Creates a new PackageMetadata from a given {@link GamePackage}.

--- a/src/classes/managers/ItemsManager.ts
+++ b/src/classes/managers/ItemsManager.ts
@@ -35,7 +35,7 @@ export class ItemsManager extends EventBasedManager<ItemEvents> {
                     this.#received[index++] = new Item(
                         this.#client,
                         networkItem,
-                        this.#client.players.findPlayer(this.#client.players.self.team, networkItem.player) as Player,
+                        this.#client.players.findPlayer(networkItem.player) as Player,
                         this.#client.players.self,
                     );
                 }

--- a/src/classes/managers/MessageManager.ts
+++ b/src/classes/managers/MessageManager.ts
@@ -1,9 +1,20 @@
-import { PrintJSONPacket, SayPacket } from "../../api";
+import { HintJSONPacket, ItemCheatJSONPacket, ItemSendJSONPacket, PrintJSONPacket, SayPacket } from "../../api";
 import { UnauthenticatedError } from "../../errors.ts";
 import { MessageEvents } from "../../events/MessageEvents.ts";
 import { Client } from "../Client.ts";
+import { Item } from "../Item.ts";
+import {
+    ColorMessageNode,
+    ItemMessageNode,
+    LocationMessageNode,
+    MessageNode,
+    PlayerMessageNode, TextualMessageNode,
+} from "../MessageNode.ts";
 import { Player } from "../Player.ts";
 import { EventBasedManager } from "./EventBasedManager.ts";
+
+/** A type for logged messages on {@link MessageManager}. */
+export type MessageLog = { text: string, nodes: MessageNode[] }[];
 
 /**
  * Manages and stores {@link PrintJSONPacket} messages, notifies subscribers of new messages, and exposes helper methods
@@ -11,16 +22,16 @@ import { EventBasedManager } from "./EventBasedManager.ts";
  */
 export class MessageManager extends EventBasedManager<MessageEvents> {
     readonly #client: Client;
-    readonly #messages: { message: string, packet: PrintJSONPacket }[] = [];
+    readonly #messages: MessageLog = [];
 
     /**
-     * Returns all current chat messages that are logged.
+     * Returns a shallow copy of all logged chat messages.
      *
      * If the messages length is greater than {@link ClientOptions.maximumMessages}, the oldest messages are spliced
      * out.
      */
-    public get messages(): { readonly message: string, readonly packet: PrintJSONPacket }[] {
-        return this.#messages;
+    public get log(): MessageLog {
+        return [...this.#messages];
     }
 
     /**
@@ -33,36 +44,13 @@ export class MessageManager extends EventBasedManager<MessageEvents> {
         this.#client = client;
 
         // Log messages and emit events.
-        this.#client.socket.on("printJSON", (packet, message) => {
-            let index = -1;
-            if (this.#client.options.maximumMessages >= 1) {
-                this.messages.push({ message, packet });
-                this.messages.splice(0, this.messages.length - this.#client.options.maximumMessages);
-                index = this.messages.length - 1;
-            }
-
-            this.emit("receivedMessage", [message, index, packet]);
-
-            // Special packets.
-            switch (packet.type) {
-                case "Chat":
-                    this.emit("chatMessage", [
-                        message,
-                        index,
-                        this.#client.players.findPlayer(packet.slot, packet.team) as Player,
-                    ]);
-                    break;
-                case "Countdown":
-                    this.emit("countdown", [message, index, packet.countdown]);
-                    break;
-            }
-        });
+        this.#client.socket.on("printJSON", this.#onPrintJSON.bind(this));
     }
 
     /**
      * Sends a chat message to the server.
      * @param text The textual message to broadcast to all connected clients.
-     * @returns A promise that resolves when the server responds with the PrintJSON packet.
+     * @returns A promise that resolves when the server has broadcast the chat message.
      * @throws UnauthenticatedError if attempting to send a chat message when not connected or authenticated.
      */
     public async say(text: string): Promise<void> {
@@ -72,8 +60,141 @@ export class MessageManager extends EventBasedManager<MessageEvents> {
 
         text = text.trim();
         const request: SayPacket = { cmd: "Say", text };
-        await this.#client.socket
-            .send(request)
-            .wait("printJSON", (_, message) => message === text);
+        this.#client.socket.send(request);
+        await this.wait("chat", (message) => message === text);
+    }
+
+    #onPrintJSON(packet: PrintJSONPacket): void {
+        // Build nodes
+        const nodes: MessageNode[] = [];
+        for (const part of packet.data) {
+            switch (part.type) {
+                case "item_id":
+                case "item_name": {
+                    const itemPacket = packet as ItemSendJSONPacket | ItemCheatJSONPacket | HintJSONPacket;
+                    let receiver: Player;
+                    if (itemPacket.type === "ItemCheat") {
+                        receiver = this.#client.players.findPlayer(itemPacket.receiving, itemPacket.team) as Player;
+                    } else {
+                        receiver = this.#client.players.findPlayer(itemPacket.receiving) as Player;
+                    }
+
+                    nodes.push(new ItemMessageNode(this.#client, part, itemPacket.item, receiver));
+                    break;
+                }
+
+                case "location_id":
+                case "location_name": {
+                    nodes.push(new LocationMessageNode(this.#client, part));
+                    break;
+                }
+
+                case "color": {
+                    nodes.push(new ColorMessageNode(this.#client, part));
+                    break;
+                }
+
+                case "player_id":
+                case "player_name": {
+                    nodes.push(new PlayerMessageNode(this.#client, part));
+                    break;
+                }
+
+                default: {
+                    nodes.push(new TextualMessageNode(this.#client, part));
+                    break;
+                }
+            }
+        }
+
+        const text = nodes.map((node) => node.text).join();
+
+        // Add the message to the log.
+        if (this.#client.options.maximumMessages >= 1) {
+            this.log.push({ text, nodes });
+            this.log.splice(0, this.log.length - this.#client.options.maximumMessages);
+        }
+
+        // Fire relevant event.
+        switch (packet.type) {
+            case "ItemSend": {
+                const sender = this.#client.players.findPlayer(packet.item.player) as Player;
+                const receiver = this.#client.players.findPlayer(packet.receiving) as Player;
+                const item = new Item(this.#client, packet.item, sender, receiver);
+                this.emit("itemSent", [text, item, nodes]);
+                break;
+            }
+            case "ItemCheat": {
+                const sender = this.#client.players.findPlayer(packet.item.player, packet.team) as Player;
+                const receiver = this.#client.players.findPlayer(packet.receiving, packet.team) as Player;
+                const item = new Item(this.#client, packet.item, sender, receiver);
+                this.emit("itemCheated", [text, item, nodes]);
+                break;
+            }
+            case "Hint": {
+                const sender = this.#client.players.findPlayer(packet.item.player) as Player;
+                const receiver = this.#client.players.findPlayer(packet.receiving) as Player;
+                const item = new Item(this.#client, packet.item, sender, receiver);
+                this.emit("itemHinted", [text, item, packet.found, nodes]);
+                break;
+            }
+            case "Join": {
+                const player = this.#client.players.findPlayer(packet.slot, packet.team) as Player;
+                this.emit("connected", [text, player, packet.tags, nodes]);
+                break;
+            }
+            case "Part": {
+                const player = this.#client.players.findPlayer(packet.slot, packet.team) as Player;
+                this.emit("disconnected", [text, player, nodes]);
+                break;
+            }
+            case "Chat": {
+                const player = this.#client.players.findPlayer(packet.slot, packet.team) as Player;
+                this.emit("chat", [packet.message, player, nodes]);
+                break;
+            }
+            case "ServerChat": {
+                this.emit("serverChat", [packet.message, nodes]);
+                break;
+            }
+            case "TagsChanged": {
+                const player = this.#client.players.findPlayer(packet.slot, packet.team) as Player;
+                this.emit("tagsUpdated", [text, player, packet.tags, nodes]);
+                break;
+            }
+            case "Tutorial": {
+                this.emit("tutorial", [text, nodes]);
+                break;
+            }
+            case "CommandResult": {
+                this.emit("userCommand", [text, nodes]);
+                break;
+            }
+            case "AdminCommandResult": {
+                this.emit("adminCommand", [text, nodes]);
+                break;
+            }
+            case "Goal": {
+                const player = this.#client.players.findPlayer(packet.slot, packet.team) as Player;
+                this.emit("goaled", [text, player, nodes]);
+                break;
+            }
+            case "Release": {
+                const player = this.#client.players.findPlayer(packet.slot, packet.team) as Player;
+                this.emit("released", [text, player, nodes]);
+                break;
+            }
+            case "Collect": {
+                const player = this.#client.players.findPlayer(packet.slot, packet.team) as Player;
+                this.emit("collected", [text, player, nodes]);
+                break;
+            }
+            case "Countdown": {
+                this.emit("countdown", [text, packet.countdown, nodes]);
+            }
+        }
+
+        // Generic event is called last.
+        this.emit("message", [text, nodes]);
     }
 }

--- a/src/classes/managers/MessageManager.ts
+++ b/src/classes/managers/MessageManager.ts
@@ -49,7 +49,7 @@ export class MessageManager extends EventBasedManager<MessageEvents> {
                     this.emit("chatMessage", [
                         message,
                         index,
-                        this.#client.players.findPlayer(packet.team, packet.slot) as Player,
+                        this.#client.players.findPlayer(packet.slot, packet.team) as Player,
                     ]);
                     break;
                 case "Countdown":

--- a/src/classes/managers/PlayersManager.ts
+++ b/src/classes/managers/PlayersManager.ts
@@ -98,11 +98,16 @@ export class PlayersManager extends EventBasedManager<PlayerEvents> {
 
     /**
      * Attempt to find a player by their team or slot name.
-     * @param team The team id associated with the searched player.
      * @param slot The slot id associated with the searched player.
+     * @param team The team id associated with the searched player. If omitted, defaults to the team of the client
+     * player.
      * @returns The player's metadata or `undefined` if not found.
      */
-    public findPlayer(team: number, slot: number): Player | undefined {
+    public findPlayer(slot: number, team?: number): Player | undefined {
+        if (team === undefined) {
+            team = this.#client.players.self.team;
+        }
+
         const playerTeam = this.#players[team];
         if (playerTeam) {
             return new Player(this.#client, this.#players[team][slot]);

--- a/src/classes/managers/SocketManager.ts
+++ b/src/classes/managers/SocketManager.ts
@@ -170,11 +170,7 @@ export class SocketManager extends EventBasedManager<SocketEvents> {
                     this.emit("locationInfo", [packet]);
                     break;
                 case "PrintJSON":
-                    if (packet.type === "Chat" || packet.type === "ServerChat") {
-                        this.emit("printJSON", [packet, packet.message]);
-                    } else {
-                        this.emit("printJSON", [packet, packet.data.reduce((prev, value) => prev + value.text, "")]);
-                    }
+                    this.emit("printJSON", [packet]);
                     break;
                 case "ReceivedItems":
                     this.emit("receivedItems", [packet]);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,4 +5,4 @@
 export const targetVersion = { major: 0, minor: 5, build: 1 };
 
 // Phar if you forget to update this on release, I swear to god.
-export const libraryVersion = "2.0.0-rc5";
+export const libraryVersion = "2.0.0-rc6";

--- a/src/events/MessageEvents.ts
+++ b/src/events/MessageEvents.ts
@@ -1,4 +1,5 @@
-import { PrintJSONPacket } from "../api";
+import { Item } from "../classes/Item.ts";
+import { MessageNode } from "../classes/MessageNode.ts";
 import { Player } from "../classes/Player.ts";
 
 /**
@@ -7,29 +8,128 @@ import { Player } from "../classes/Player.ts";
  */
 export type MessageEvents = {
     /**
-     * Fires when any message is received.
+     * Fires when any kind of message is received.
      * @param message The plaintext message content.
-     * @param index The index of this message in {@link MessageManager.messages}, when this event was fired. If message
-     * logging is disabled, this will return `-1`.
-     * @param packet The received PrintJSONPacket, if needed to reconstruct into a specialized message.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    receivedMessage: [message: string, index: number, packet: PrintJSONPacket]
+    message: [message: string, nodes: MessageNode[]]
+
+    /**
+     * Fires when another player is sent an item (except for cheated items).
+     * @param message The plaintext message content.
+     * @param item The item being sent.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    itemSent: [message: string, item: Item, nodes: MessageNode[]]
+
+    /**
+     * Fires when another player is sent a cheated item.
+     * @param message The plaintext message content.
+     * @param item The item being sent.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    itemCheated: [message: string, item: Item, nodes: MessageNode[]]
+
+    /**
+     * Fires when a hint-style message is received.
+     * @param message The plaintext message content.
+     * @param item The item being hinted.
+     * @param found If the item was found.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     * @remarks This event is for hint messages received. To track more information on when hints are updated, utilize
+     * one of the hint-type events on {@link ItemsManager} instead.
+     */
+    itemHinted: [message: string, item: Item, found: boolean, nodes: MessageNode[]]
+
+    /**
+     * Fires when a client connects to the room session.
+     * @param message The plaintext message content.
+     * @param player The player being connected as.
+     * @param tags The tags of the joining client.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    connected: [message: string, player: Player, tags: string[], nodes: MessageNode[]]
+
+    /**
+     * Fires when a client disconnects from the room session.
+     * @param message The plaintext message content.
+     * @param player The player being disconnected from.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    disconnected: [message: string, player: Player, nodes: MessageNode[]]
+
+    /**
+     * Fires when a player chat message is received.
+     * @param message The plaintext message content.
+     * @param player The metadata of the player who sent this message.
+     */
+    chat: [message: string, player: Player]
+
+    /**
+     * Fires when a server chat message is received.
+     * @param message The plaintext message content.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    serverChat: [message: string, nodes: MessageNode[]]
+
+    /**
+     * Fires when tutorial-like information is received, such as on first connection explaining `!help`.
+     * @param message The plaintext message content.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    tutorial: [message: string, nodes: MessageNode[]]
+
+    /**
+     * Fires when a client updates their tags.
+     * @param message The plaintext message content.
+     * @param player The player this client is connected to.
+     * @param tags The new tags for this client.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    tagsUpdated: [message: string, player: Player, tags: string[], nodes: MessageNode[]]
+
+    /**
+     * Fires on the result of running a user command, such as `!status`.
+     * @param message The plaintext message content.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    userCommand: [message: string, nodes: MessageNode[]]
+
+    /**
+     * Fires on the result of running an admin command via `!admin`.
+     * @param message The plaintext message content.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    adminCommand: [message: string, nodes: MessageNode[]]
+
+    /**
+     * Fires when a connected player has met their goal condition.
+     * @param message The plaintext message content.
+     * @param player The player that reached their goal.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    goaled: [message: string, player: Player, nodes: MessageNode[]]
+
+    /**
+     * Fires when a player has released their remaining items to the multi-world.
+     * @param message The plaintext message content.
+     * @param player The player that released.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    released: [message: string, player: Player, nodes: MessageNode[]]
+
+    /**
+     * Fires when a player has collected their remaining items from the multi-world.
+     * @param message The plaintext message content.
+     * @param player The player that collected.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     */
+    collected: [message: string, player: Player, nodes: MessageNode[]]
 
     /**
      * Fires when a countdown message is received.
      * @param message The plaintext message content.
-     * @param index The index of this message in {@link MessageManager.messages}, when this event was fired. If message
-     * logging is disabled, this will return `-1`.
      * @param value The current countdown value.
      */
-    countdown: [message: string, index: number, value: number]
-
-    /**
-     * Fires when a player message is received.
-     * @param message The plaintext message content.
-     * @param index The index of this message in {@link MessageManager.messages}, when this event was fired. If message
-     * logging is disabled, this will return `-1`.
-     * @param sender The metadata of the player who sent this message.
-     */
-    chatMessage: [message: string, index: number, sender: Player]
+    countdown: [message: string, value: number]
 };

--- a/src/events/MessageEvents.ts
+++ b/src/events/MessageEvents.ts
@@ -9,127 +9,131 @@ import { Player } from "../classes/Player.ts";
 export type MessageEvents = {
     /**
      * Fires when any kind of message is received.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    message: [message: string, nodes: MessageNode[]]
+    message: [text: string, nodes: MessageNode[]]
 
     /**
      * Fires when another player is sent an item (except for cheated items).
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param item The item being sent.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    itemSent: [message: string, item: Item, nodes: MessageNode[]]
+    itemSent: [text: string, item: Item, nodes: MessageNode[]]
 
     /**
      * Fires when another player is sent a cheated item.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param item The item being sent.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    itemCheated: [message: string, item: Item, nodes: MessageNode[]]
+    itemCheated: [text: string, item: Item, nodes: MessageNode[]]
 
     /**
      * Fires when a hint-style message is received.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param item The item being hinted.
      * @param found If the item was found.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      * @remarks This event is for hint messages received. To track more information on when hints are updated, utilize
      * one of the hint-type events on {@link ItemsManager} instead.
      */
-    itemHinted: [message: string, item: Item, found: boolean, nodes: MessageNode[]]
+    itemHinted: [text: string, item: Item, found: boolean, nodes: MessageNode[]]
 
     /**
      * Fires when a client connects to the room session.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param player The player being connected as.
      * @param tags The tags of the joining client.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    connected: [message: string, player: Player, tags: string[], nodes: MessageNode[]]
+    connected: [text: string, player: Player, tags: string[], nodes: MessageNode[]]
 
     /**
      * Fires when a client disconnects from the room session.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param player The player being disconnected from.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    disconnected: [message: string, player: Player, nodes: MessageNode[]]
+    disconnected: [text: string, player: Player, nodes: MessageNode[]]
 
     /**
      * Fires when a player chat message is received.
-     * @param message The plaintext message content.
+     * @param message The plaintext message content without the sender name prefix.
      * @param player The metadata of the player who sent this message.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
+     * @remarks `nodes` will contain the sender name prefix from the server, but `message` will not.
      */
-    chat: [message: string, player: Player]
+    chat: [message: string, player: Player, nodes: MessageNode[]]
 
     /**
      * Fires when a server chat message is received.
-     * @param message The plaintext message content.
+     * @param message The plaintext message content without the sender name prefix.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
+     * @remarks `nodes` will contain the sender name prefix from the server, but `message` will not.
      */
     serverChat: [message: string, nodes: MessageNode[]]
 
     /**
      * Fires when tutorial-like information is received, such as on first connection explaining `!help`.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    tutorial: [message: string, nodes: MessageNode[]]
+    tutorial: [text: string, nodes: MessageNode[]]
 
     /**
      * Fires when a client updates their tags.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param player The player this client is connected to.
      * @param tags The new tags for this client.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    tagsUpdated: [message: string, player: Player, tags: string[], nodes: MessageNode[]]
+    tagsUpdated: [text: string, player: Player, tags: string[], nodes: MessageNode[]]
 
     /**
      * Fires on the result of running a user command, such as `!status`.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    userCommand: [message: string, nodes: MessageNode[]]
+    userCommand: [text: string, nodes: MessageNode[]]
 
     /**
      * Fires on the result of running an admin command via `!admin`.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    adminCommand: [message: string, nodes: MessageNode[]]
+    adminCommand: [text: string, nodes: MessageNode[]]
 
     /**
      * Fires when a connected player has met their goal condition.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param player The player that reached their goal.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    goaled: [message: string, player: Player, nodes: MessageNode[]]
+    goaled: [text: string, player: Player, nodes: MessageNode[]]
 
     /**
      * Fires when a player has released their remaining items to the multi-world.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param player The player that released.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    released: [message: string, player: Player, nodes: MessageNode[]]
+    released: [text: string, player: Player, nodes: MessageNode[]]
 
     /**
      * Fires when a player has collected their remaining items from the multi-world.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param player The player that collected.
      * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    collected: [message: string, player: Player, nodes: MessageNode[]]
+    collected: [text: string, player: Player, nodes: MessageNode[]]
 
     /**
      * Fires when a countdown message is received.
-     * @param message The plaintext message content.
+     * @param text The plaintext message content.
      * @param value The current countdown value.
+     * @param nodes An array of message nodes in this message with additional context for each textual component.
      */
-    countdown: [message: string, value: number]
+    countdown: [text: string, value: number, nodes: MessageNode[]]
 };

--- a/src/events/SocketEvents.ts
+++ b/src/events/SocketEvents.ts
@@ -73,7 +73,7 @@ export type SocketEvents = {
      * @param packet The raw {@link PrintJSONPacket} packet.
      * @param message The full plaintext message content.
      */
-    printJSON: [packet: PrintJSONPacket, message: string]
+    printJSON: [packet: PrintJSONPacket]
 
     /**
      * Fires when the client receives a {@link ReceivedItemsPacket}.

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export * from "./classes/managers/MessageManager.ts";
 export * from "./classes/managers/PlayersManager.ts";
 export * from "./classes/managers/RoomStateManager.ts";
 export * from "./classes/managers/SocketManager.ts";
+export * from "./classes/MessageNode.ts";
 export * from "./classes/PackageMetadata.ts";
 export * from "./classes/Player.ts";
 export * from "./constants.ts";

--- a/typedoc.json
+++ b/typedoc.json
@@ -15,7 +15,7 @@
         "@shipgirl/typedoc-plugin-versions"
     ],
     "versions": {
-        "stable": "2.0.0-rc5"
+        "stable": "2.0"
     },
 
     "projectDocuments": ["guides/*.md"]


### PR DESCRIPTION
* Update version to `2.0.0-rc6`.
* Fix issue with `Client.scout` not resolving after fetching `LocationInfo` packet.
* Change type on `PackageMetadata.reverseItemTable` and `PackageMetadata.reverseLocationTable` to `Record<number, string>` instead of `Record<string, string>`.
* Reverse the parameter order of `PlayersManager.findPlayer` and make team optional, defaulting to client's team if omitted.
* Remove `index` from all `MessageEvents` since it will just be `MessageManager.count - 1` anyway.
* Add a new abstract class called `MessageNode` which encapsulates `JSONMessagePart` and exposes helper methods and other abstracted classes.
* Update existing `MessageEvents` to return `MessageNode[]` instead of raw `PrintJSONPacket`.
* Add a new message event for each supported `PrintJSON` packet type the server can broadcast.
* Rename `MessageEvents.receivedMessage` to `MessageEvents.message` and `MessageEvents.chatMessage` to `MessageEvents.chat`.
* The `MessageEvents.message` event now fires after all more specific `MessageEvents` have fired.
* Renamed `MessageManager.messages` to `MessageManager.log` and changed it to return a shallow copy of log instead of direct array to prevent accidental modifications.
  * ~~`client.messages.log` looks less silly than `client.messages.messages`.~~
* Update documentation with changes made.