### PR TITLE
Hints: Ensure `hints` order is guaranteed on `ItemsManager` and fix accidental overriding of previous hints.

### DIFF
--- a/src/classes/Hint.ts
+++ b/src/classes/Hint.ts
@@ -42,4 +42,12 @@ export class Hint {
     get entrance(): string {
         return this.#hint.entrance || "Vanilla";
     }
+
+    get uniqueId(): string {
+        return `${this.#item.sender.slot}-${this.#item.locationId}`;
+    }
+
+    static getUniqueKey(hint: NetworkHint): string {
+        return `${hint.finding_player}-${hint.item}`;
+    }
 }

--- a/src/classes/Hint.ts
+++ b/src/classes/Hint.ts
@@ -43,11 +43,11 @@ export class Hint {
         return this.#hint.entrance || "Vanilla";
     }
 
-    get uniqueId(): string {
+    get uniqueKey(): string {
         return `${this.#item.sender.slot}-${this.#item.locationId}`;
     }
 
     static getUniqueKey(hint: NetworkHint): string {
-        return `${hint.finding_player}-${hint.item}`;
+        return `${hint.finding_player}-${hint.location}`;
     }
 }

--- a/src/classes/managers/ItemsManager.ts
+++ b/src/classes/managers/ItemsManager.ts
@@ -59,7 +59,7 @@ export class ItemsManager extends EventBasedManager<ItemEvents> {
                             this.#hintIndexLookup.set(newHint.uniqueKey, index);
                             return newHint;
                         });
-                        this.emit("hintsInitialized", [[...this.#hints.values()]]);
+                        this.emit("hintsInitialized", [[...this.#hints]]);
                     })
                     .catch((error) => {
                         throw error;
@@ -79,7 +79,7 @@ export class ItemsManager extends EventBasedManager<ItemEvents> {
      * {@link ItemEvents.hintsInitialized} event.
      */
     public get hints(): Hint[] {
-        return [...this.#hints.values()];
+        return [...this.#hints];
     }
 
     /** Return the number of items received. */


### PR DESCRIPTION
The Archipelago server does not store hints in order of when they were created. As a result, archipelago.js would duplicate and overwrite hints in an unexpected manner when getting hint updates.

This PR aims to resolve this by doing the following:
- Providing a way to create a key for a given hint and network hint based on the finding player's world and location (should be unique among all hints)
- Provide a quick way to determine if we have seen a hint before using said key, and where it is stored in our list of hints
     - If this is a new hint, we add it to our list, if it is an old one that needs to be updated, we replace the old hint in the list. 
- Maintain the order the hints were received in

I tested this by building archipelago.js and building my web app using that and verified that in cases where hints would be lost/duplicated before no longer occurred with this version. 

I did not test this in other frameworks outside of a web-browser, I did double check the support for any features I used and ensured they are available for use with ES2022.