### PR TITLE
Use empty string as separator

### DIFF
--- a/src/classes/managers/MessageManager.ts
+++ b/src/classes/managers/MessageManager.ts
@@ -107,7 +107,7 @@ export class MessageManager extends EventBasedManager<MessageEvents> {
             }
         }
 
-        const text = nodes.map((node) => node.text).join();
+        const text = nodes.map((node) => node.text).join("");
 
         // Add the message to the log.
         if (this.#client.options.maximumMessages >= 1) {


### PR DESCRIPTION
Specify empty string as separator when generating text for multi-part messages.