### PR TITLE
Data package handling improvements

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -39,7 +39,7 @@ export type GamePackage = {
     readonly checksum: string
 };
 
-/** An interface for fetching data packages from a cache, Should return a {@link GamePackage} if available, lese null */
+/** An interface for fetching data packages from a cache, Should return a {@link GamePackage} if available, else null */
 export interface DataPackageCache {
     getPackage(game: string, checksum?: string): Promise<GamePackage | null>
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -39,6 +39,11 @@ export type GamePackage = {
     readonly checksum: string
 };
 
+/** An interface for fetching data packages from a cache, Should return a {@link GamePackage} if available, lese null */
+export interface DataPackageCache {
+    getPackage(game: string, checksum?: string): Promise<GamePackage | null>
+}
+
 /** A type union of all basic JSON-compatible types. */
 export type JSONSerializable =
     | string

--- a/src/classes/Client.ts
+++ b/src/classes/Client.ts
@@ -74,7 +74,7 @@ export class Client {
         } else {
             this.options = { ...defaultClientOptions };
         }
-
+        console.log("hello");
         // Setup disconnection event handler to reset internal state.
         this.socket
             .on("disconnected", () => {

--- a/src/classes/Client.ts
+++ b/src/classes/Client.ts
@@ -74,7 +74,7 @@ export class Client {
         } else {
             this.options = { ...defaultClientOptions };
         }
-        console.log("hello");
+
         // Setup disconnection event handler to reset internal state.
         this.socket
             .on("disconnected", () => {

--- a/src/classes/managers/DataPackageManager.ts
+++ b/src/classes/managers/DataPackageManager.ts
@@ -1,4 +1,4 @@
-import { DataPackage, GamePackage, GetDataPackagePacket } from "../../api";
+import { DataPackage, DataPackageCache, GamePackage, GetDataPackagePacket } from "../../api";
 import { Client } from "../Client.ts";
 import { PackageMetadata } from "../PackageMetadata.ts";
 
@@ -10,6 +10,7 @@ export class DataPackageManager {
     readonly #packages: Map<string, PackageMetadata> = new Map();
     readonly #checksums: Map<string, string> = new Map();
     readonly #games: Set<string> = new Set();
+    #cache: DataPackageCache | null = null;
 
     /**
      * Instantiates a new DataPackageManager. Should only be instantiated by creating a new {@link Client}.
@@ -37,6 +38,10 @@ export class DataPackageManager {
      */
     public findPackage(game: string): PackageMetadata | null {
         return this.#packages.get(game) ?? null;
+    }
+
+    public setCache(cache: DataPackageCache) {
+        this.#cache = cache;
     }
 
     /**
@@ -68,6 +73,24 @@ export class DataPackageManager {
             // Any other situation, it's not needed.
             return false;
         });
+
+        // Check for games in cache prior to requesting data package from server
+        if (this.#cache) {
+            const data: DataPackage = { games: {} };
+            const notFoundGames = [];
+            for (const game of games) {
+                const cachedPackage = await this.#cache.getPackage(game, this.#checksums.get(game));
+                if (cachedPackage) {
+                    data.games[game] = cachedPackage;
+                } else {
+                    notFoundGames.push(game);
+                }
+            }
+            if (update) {
+                this.importPackage(data);
+            }
+            games = notFoundGames;
+        }
 
         // Request each game individually to reduce likelihood of a large packet causing a spike in network usage.
         const data: DataPackage = { games: {} };

--- a/src/classes/managers/DataPackageManager.ts
+++ b/src/classes/managers/DataPackageManager.ts
@@ -19,7 +19,6 @@ export class DataPackageManager {
     public constructor(client: Client) {
         this.#client = client;
         this.#client.socket.on("roomInfo", (packet) => {
-            this.#packages.clear();
             this.#checksums.clear();
             this.#games.clear();
 

--- a/src/classes/managers/DataPackageManager.ts
+++ b/src/classes/managers/DataPackageManager.ts
@@ -138,7 +138,7 @@ export class DataPackageManager {
      */
     public exportPackage(): DataPackage {
         return {
-            games: this.#packages.entries().reduce((games, [game, pkg]) => {
+            games: [...this.#packages.entries()].reduce((games, [game, pkg]) => {
                 games[game] = pkg.exportPackage();
                 return games;
             }, {} as Record<string, GamePackage>),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "rootDir": "./src/",
-        "target": "ES2022",
+        "target": "ES2023",
         "module": "ES2022",
         "moduleResolution": "Node",
         "esModuleInterop": true,


### PR DESCRIPTION
This PR is provided as a suggestion to improve data package handling. I have put these to use in my fork of archipelago.js and have had good results. This PR should help reduce the initial stress that clients using archipelago.js put on the Archipelago servers they connect to.

This PR does the following:
- Makes it possible to used cached data packages #225
- Adds an interface `DataPackageCache` that can be supplied by the using application to allow archipelago.js to request specific game packages rather than having the using application supply all data packages at once. [Example Implentation](https://github.com/DrAwesome4333/ap-tracker/blob/main/src/services/MultiInfo/DatapackageHelper.ts)
- Addresses some incompatibilities between what was set in the config, vs what was defined in the code. `.toSorted()` requires ES 2023 and above.