### PR TITLE
FIX: push messages onto the original log array and not the shallow copy

### DIFF
--- a/src/classes/managers/MessageManager.ts
+++ b/src/classes/managers/MessageManager.ts
@@ -111,8 +111,8 @@ export class MessageManager extends EventBasedManager<MessageEvents> {
 
         // Add the message to the log.
         if (this.#client.options.maximumMessages >= 1) {
-            this.log.push({ text, nodes });
-            this.log.splice(0, this.log.length - this.#client.options.maximumMessages);
+            this.#messages.push({ text, nodes });
+            this.#messages.splice(0, this.#messages.length - this.#client.options.maximumMessages);
         }
 
         // Fire relevant event.


### PR DESCRIPTION
Noticed this issue in the client I'm working on, fortunately it's a pretty easy/quick fix.

Tested using `bun link` in my WIP client and seems to be working now.