### PR TITLE
Fix `ClientOptions.debugLogVersions` not being optional.

### DIFF
--- a/src/interfaces/ClientOptions.ts
+++ b/src/interfaces/ClientOptions.ts
@@ -27,8 +27,9 @@ export interface ClientOptions {
      * If enabled, logs the game, library version, and user agent to data storage, which can be used for debugging
      * purposes.
      * @default true
+     * @deprecated This functionality will be removed in version 3.0.0.
      */
-    debugLogVersions: boolean
+    debugLogVersions?: boolean
 }
 
 /**
@@ -39,5 +40,5 @@ export const defaultClientOptions: Required<ClientOptions> = {
     timeout: 10000,
     autoFetchDataPackage: true,
     maximumMessages: 1000,
-    debugLogVersions: true,
+    debugLogVersions: false,
 };


### PR DESCRIPTION
Marking this as optional as well as I plan to remove this in the 3.0 version of the library.

Fixes #226.