### PR TITLE
Upgrade findPlayer implementation to match documenation

### DIFF
--- a/src/classes/managers/PlayersManager.ts
+++ b/src/classes/managers/PlayersManager.ts
@@ -106,14 +106,24 @@ export class PlayersManager extends EventBasedManager<PlayerEvents> {
      * player.
      * @returns The player's metadata or `undefined` if not found.
      */
-    public findPlayer(slot: number, team?: number): Player | undefined {
+    public findPlayer(slot: number | string, team?: number): Player | undefined {
         if (team === undefined) {
             team = this.#client.players.self.team;
         }
 
         const playerTeam = this.#players[team];
-        if (playerTeam) {
-            return new Player(this.#client, this.#players[team][slot]);
+        if (!playerTeam) {
+            return undefined;
+        }
+
+        if (playerTeam[slot]) {
+            return new Player(this.#client, playerTeam[slot]);
+        }
+
+        for (let teamSlot of playerTeam) {
+            if (teamSlot.name === slot) {
+                return new Player(this.#client, teamSlot);
+            }
         }
 
         return undefined;


### PR DESCRIPTION
The doc comment on findPlayer reads "Attempt to find a player by their team or slot name".

Currently, it *only* returns `undefined` if given an invalid team id, otherwise constructing a Player object with invalid data if not passed a valid player id. This breaks both the documented behaviour and the expectation set by naming the method 'find' instead of 'get'.

At least one existing game expects findPlayer to accept slot names; I found the discrepancy while playing Jigsaw and seeing it throw exceptions when responding to deathlink events (notably, which archipelago.js itself passes a slot name as the source, rather than an id or player object).

This PR brings the implementation in line with expectations set by the comment and function name. I considered also including a scan comparing slot alias if no names matched, but that arguably goes beyond documented behaviour, and therefore is not my call to make.